### PR TITLE
Add lock to queue_services

### DIFF
--- a/gateway/tasks.py
+++ b/gateway/tasks.py
@@ -3,7 +3,6 @@ from contextlib import contextmanager
 
 import requests
 from celery import shared_task
-from celery.utils.log import get_task_logger
 from django.core.cache import cache
 from django.utils import timezone
 from django_celery_results.models import TaskResult
@@ -21,9 +20,7 @@ method_map = {
 }
 
 
-logger = get_task_logger(__name__)
-
-LOCK_EXPIRE = 60 * 15  # Lock expires in 15 minutes
+LOCK_EXPIRE = 60 * 10  # Lock expires in 10 minutes
 
 
 @contextmanager

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 celery==5.1.2
-Django==3.2.10
+Django==3.2.12
 django-celery-beat==2.2.1
 django-celery-results==2.2.0
 django-crispy-forms==1.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-amqp==5.0.7
+amqp==5.0.9
     # via kombu
 asgiref==3.4.1
     # via django
@@ -19,7 +19,7 @@ celery==5.1.2
     #   django-celery-results
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.9
+charset-normalizer==2.0.11
     # via requests
 click==7.1.2
     # via
@@ -33,7 +33,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-django==3.2.10
+django==3.2.12
     # via
     #   -r requirements.in
     #   django-celery-beat
@@ -47,17 +47,17 @@ django-crispy-forms==1.13.0
     # via -r requirements.in
 django-datatables-view==1.19.1
     # via -r requirements.in
-django-timezone-field==4.2.1
+django-timezone-field==4.2.3
     # via django-celery-beat
 djangorestframework==3.12.4
     # via -r requirements.in
 idna==3.3
     # via requests
-importlib-metadata==4.8.2
+importlib-metadata==4.8.3
     # via kombu
 kombu==5.1.0
     # via celery
-prompt-toolkit==3.0.24
+prompt-toolkit==3.0.27
     # via click-repl
 psycopg2-binary==2.9.1
     # via -r requirements.in
@@ -84,7 +84,7 @@ typing-extensions==4.0.1
     # via
     #   asgiref
     #   importlib-metadata
-urllib3==1.26.7
+urllib3==1.26.8
     # via requests
 vine==5.0.0
     # via


### PR DESCRIPTION
Attempt at fixing #169 by using https://docs.celeryproject.org/en/stable/tutorials/task-cookbook.html#ensuring-a-task-is-only-executed-one-at-a-time

I was having trouble getting Zodiac running local (an error about not being able to find manage.py) so I haven't run tests and I feel like this is not 100% there. But this is what I have so far...