### PR TITLE
Display error messages consistently

### DIFF
--- a/gateway/models.py
+++ b/gateway/models.py
@@ -137,7 +137,7 @@ class RequestLog(models.Model):
 
     @property
     def error_messages(self):
-        #todo fix it here.
+        # todo fix it here.
         errors = []
         if self.task_result:
             for e in json.loads(self.task_result.result).get('exc_message'):
@@ -145,9 +145,9 @@ class RequestLog(models.Model):
                     emess = e.get('detail')
                 except BaseException:
                     try:
-                        code = int(e[e.find("[")+1:e.find("]")])
+                        code = int(e[e.find("[") + 1:e.find("]")])
                         emess = f"{e}: {responses[code]}"
-                    except:
+                    except BaseException:
                         emess = e
                 errors.append(emess)
         return errors

--- a/gateway/models.py
+++ b/gateway/models.py
@@ -1,4 +1,5 @@
 import json
+from http.client import responses
 
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
@@ -134,13 +135,19 @@ class RequestLog(models.Model):
     task_result = models.ForeignKey(TaskResult, on_delete=models.CASCADE, blank=True, null=True, related_name='request_log')
     task_result_status = models.CharField(max_length=100, choices=(('success', 'Success'), ('error', 'Error'), ('idle', 'Idle')), blank=True, null=True)
 
+    @property
     def error_messages(self):
+        #todo fix it here.
         errors = []
         if self.task_result:
             for e in json.loads(self.task_result.result).get('exc_message'):
                 try:
                     emess = e.get('detail')
                 except BaseException:
-                    emess = e
+                    try:
+                        code = int(e[e.find("[")+1:e.find("]")])
+                        emess = f"{e}: {responses[code]}"
+                    except:
+                        emess = e
                 errors.append(emess)
         return errors

--- a/gateway/tests.py
+++ b/gateway/tests.py
@@ -229,6 +229,6 @@ class GatewayTestCase(TestCase):
             service = random.choice(ServiceRegistry.objects.all())
             request_log = RequestLog.objects.create(service=service, task_result=task_result)
             self.assertEqual(request_log.error_messages, expected)
-        
+
     def tearDown(self):
         TaskResult.objects.all().delete()

--- a/gateway/tests.py
+++ b/gateway/tests.py
@@ -222,10 +222,13 @@ class GatewayTestCase(TestCase):
 
     def test_error_messages(self):
         """Tests the error_messages model method of RequestLog"""
-        task_result = TaskResult.objects.create(result="{\"exc_message\": [\"foo\", {\"detail\": \"bar\"}]}")
-        service = random.choice(ServiceRegistry.objects.all())
-        request_log = RequestLog.objects.create(service=service, task_result=task_result)
-        self.assertEqual(request_log.error_messages(), ["foo", "bar"])
-
+        for task_id, result, expected in [
+                (1, "{\"exc_message\": [\"foo\", {\"detail\": \"bar\"}]}", ["foo", "bar"]),
+                (2, "{\"exc_message\": [\"<Response [500]>\"]}", ["<Response [500]>: Internal Server Error"])]:
+            task_result = TaskResult.objects.create(task_id=task_id, result=result)
+            service = random.choice(ServiceRegistry.objects.all())
+            request_log = RequestLog.objects.create(service=service, task_result=task_result)
+            self.assertEqual(request_log.error_messages, expected)
+        
     def tearDown(self):
         TaskResult.objects.all().delete()

--- a/gateway/views.py
+++ b/gateway/views.py
@@ -1,6 +1,3 @@
-import json
-from http.client import responses
-
 from dateutil import tz
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import LoginView, LogoutView

--- a/gateway/views.py
+++ b/gateway/views.py
@@ -1,4 +1,5 @@
 import json
+from http.client import responses
 
 from dateutil import tz
 from django.contrib.auth.decorators import login_required
@@ -246,8 +247,9 @@ class ResultsDatatableView(BaseDatatableView):
         task_result = ''
         if result.task_result:
             task_result = result.task_result.result
-            if 'exc_message' in result.task_result.result:
-                task_result = str(json.loads(result.task_result.result).get('exc_message')[0])
+            # Handle HTTP errors
+            if len(result.errors):
+                task_result = "\n".join(result.errors)
         return task_result
 
     def get_status_display(self, status):


### PR DESCRIPTION
Error messages (particularly HTTP errors) are currently displayed in a variety of formats in the app. This brings them all into alignment.