### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ celery==5.2.7
     #   django-celery-results
 certifi==2022.12.7
     # via requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -66,7 +66,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements.in
     #   python-crontab
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   celery
     #   django-timezone-field
@@ -79,9 +79,9 @@ six==1.16.0
     #   python-dateutil
 sqlparse==0.4.3
     # via django
-tzdata==2022.7
+tzdata==2023.3
     # via django-celery-beat
-urllib3==1.26.14
+urllib3==1.26.15
     # via requests
 vine==5.0.0
     # via


### PR DESCRIPTION
Updates some dependencies.

The introduction of Django 4.2 and django-celery-beat 2.5.0 is introducing a strange JSON parse error in tests. This may be a bug in the library; let's see what happens next month.